### PR TITLE
Solved packets not loading problem, but it works only on telegram

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,8 +46,8 @@
         </div>
     </main>
 
-    <script src="/src/js/mapProcessing.js"></script>
-    <script src="/src/js/telegramUtils.js"></script>
+    <script src="./src/js/mapProcessing.js"></script>
+    <script src="./src/js/telegramUtils.js"></script>
     <script>
         // creating alias for window.Telegram.WebApp for easier access
         let tg = window.Telegram.WebApp;

--- a/index.html
+++ b/index.html
@@ -10,8 +10,16 @@
     <!-- Telegram API -->
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <!-- LeafletJS API -->
+    <!--
     <link rel="stylesheet" href="./node_modules/leaflet/dist/leaflet.css"/>
     <script src="./node_modules/leaflet/dist/leaflet.js"></script>
+    -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+                integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+                crossorigin=""/>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+            integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+            crossorigin=""></script>
     <!-- Google Fonts import -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
There is a solution to packets not loading problem.
 
I don't know what wrong with local files of leaflet, but files on dedicated server work pretty well. It says that files are not found. It could be due to wrong leaflet file imports (I see it very different importing from dedicated server and the way it was done). Maybe github pages do not compile all files in its VM. Maybe thy are too deep in file system. I don't know I'm just guessing.

Also, I changed mapProsessing.js and telegramUtils.js path to related ones and it works now. 